### PR TITLE
Feature/23-implement-basic-unit-test-suite-with-pytest 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,46 @@ To run only the 11th tournaments of the file (for example, if you find some issu
 ```python fexerj-rating-calculator.py tournaments.csv 11 1 players.csv```
 
 
+## IDE setup (PyCharm)
+
+To fix "unresolved reference" warnings in PyCharm, mark `old/` as a Sources Root:
+
+Right-click the `old/` folder in the Project panel → **Mark Directory as** → **Sources Root**.
+
+This is only needed for IDE highlighting — `pytest` resolves imports correctly for everyone via `pythonpath = old` in `pytest.ini`.
+
+## Running the tests
+
+Unit tests are located in `old/tests/` and use the [pytest](https://docs.pytest.org/) framework.
+
+To run all tests from the project root:
+
+```bash
+python3 -m pytest
+```
+
+To run with detailed output:
+
+```bash
+python3 -m pytest -v
+```
+
+To run a specific test file:
+
+```bash
+python3 -m pytest old/tests/test_tournament_player.py -v
+```
+
+To run a specific test class or method:
+
+```bash
+python3 -m pytest old/tests/test_tournament_player.py::TestGetCurrentK -v
+python3 -m pytest old/tests/test_tournament_player.py::TestGetCurrentK::test_entry_at_80_games -v
+```
+
+
 ## TODO
 
 * Error handling for common mistakes and errors
 * Split code in modules
-* Unit testing
 * Integration testing

--- a/old/tests/conftest.py
+++ b/old/tests/conftest.py
@@ -1,0 +1,112 @@
+"""Shared pytest fixtures for the fexerj-rating-calculator test suite."""
+import textwrap
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from classes import FexerjPlayer, TournamentPlayer, Tournament
+
+
+@pytest.fixture
+def sample_fexerj_player():
+    """A fully populated FexerjPlayer instance."""
+    return FexerjPlayer(
+        id_fexerj=1,
+        id_cbx="36633",
+        title="",
+        name="JOSE DA SILVA",
+        last_rating=1500,
+        club="CLUBE XADREZ RJ",
+        birthday="01/01/1990",
+        sex="M",
+        federation="BRA",
+        total_games=50,
+        sum_opponents_ratings=0,
+        points_against_opponents=0.0,
+    )
+
+
+def _make_tournament_player(tournament=None, **kwargs):
+    """Helper: build a TournamentPlayer without making HTTP calls."""
+    if tournament is None:
+        tournament = MagicMock()
+    with patch.object(TournamentPlayer, "load_player_page"):
+        player = TournamentPlayer(tournament, "http://fake-url")
+    player.snr = kwargs.get("snr", 1)
+    player.name = kwargs.get("name", "Test Player")
+    player.id = kwargs.get("id", 100)
+    player.opponents = kwargs.get("opponents", {})
+    player.is_unrated = kwargs.get("is_unrated", False)
+    player.is_temp = kwargs.get("is_temp", False)
+    player.last_rating = kwargs.get("last_rating", 1500)
+    player.last_total_games = kwargs.get("last_total_games", 50)
+    player.last_sum_oppon_ratings = kwargs.get("last_sum_oppon_ratings", 0)
+    player.last_pts_against_oppon = kwargs.get("last_pts_against_oppon", 0.0)
+    player.this_pts_against_oppon = kwargs.get("this_pts_against_oppon", None)
+    player.this_sum_oppon_ratings = kwargs.get("this_sum_oppon_ratings", None)
+    player.this_avg_oppon_rating = kwargs.get("this_avg_oppon_rating", None)
+    player.this_games = kwargs.get("this_games", None)
+    player.this_score = kwargs.get("this_score", None)
+    player.this_expected_points = kwargs.get("this_expected_points", None)
+    player.this_points_above_expected = kwargs.get("this_points_above_expected", None)
+    player.new_rating = kwargs.get("new_rating", None)
+    player.new_total_games = kwargs.get("new_total_games", None)
+    player.new_sum_oppon_ratings = kwargs.get("new_sum_oppon_ratings", None)
+    player.new_pts_against_oppon = kwargs.get("new_pts_against_oppon", None)
+    player.calc_rule = kwargs.get("calc_rule", None)
+    player.last_k = kwargs.get("last_k", None)
+    return player
+
+
+@pytest.fixture
+def make_tournament_player():
+    """Factory fixture: returns a callable that creates TournamentPlayer instances."""
+    return _make_tournament_player
+
+
+@pytest.fixture
+def established_player(make_tournament_player):
+    """An established player (>=15 games) with rating 1500."""
+    return make_tournament_player(last_total_games=50, last_rating=1500, is_unrated=False, is_temp=False)
+
+
+@pytest.fixture
+def temp_player(make_tournament_player):
+    """A temporary player (1-14 games)."""
+    return make_tournament_player(last_total_games=5, last_rating=1400, is_unrated=False, is_temp=True)
+
+
+@pytest.fixture
+def unrated_player(make_tournament_player):
+    """An unrated player (0 games)."""
+    return make_tournament_player(last_total_games=0, last_rating=0, is_unrated=True, is_temp=False)
+
+
+# ---- Rating-list CSV fixture ----
+
+RATING_LIST_CSV = textwrap.dedent("""\
+    Id_No;Id_CBX;Title;Name;Rtg_Nat;ClubName;Birthday;Sex;Fed;TotalNumGames;SumOpponRating;TotalPoints
+    1;;; JOSE DA SILVA;1500;CLUBE A;01/01/1990;M;BRA;50;0;0
+    2;36633;;MARIO SOUZA;1800;CLUBE B;15/06/1985;M;BRA;100;0;0
+    3;;;ANA LIMA;1200;CLUBE C;20/03/2000;F;BRA;5;30000;2.5
+""")
+
+
+@pytest.fixture
+def make_tournament():
+    """Factory fixture: returns a callable that creates Tournament instances."""
+    def _make(is_irt=0, is_fexerj=1, rating_list=None, cbx_to_fexerj=None):
+        rc = MagicMock()
+        rc.rating_list = rating_list if rating_list is not None else {}
+        rc.cbx_to_fexerj = cbx_to_fexerj if cbx_to_fexerj is not None else {}
+        data = ["1", "12345", "Test Tournament", "2025-01-01", "SS", str(is_irt), str(is_fexerj)]
+        return Tournament(rc, data)
+    return _make
+
+
+@pytest.fixture
+def rating_list_csv_path(tmp_path):
+    """Write the sample rating list to a temp CSV file and return its path."""
+    csv_file = tmp_path / "ratings.csv"
+    csv_file.write_text(RATING_LIST_CSV)
+    return str(csv_file)

--- a/old/tests/test_fexerj_player.py
+++ b/old/tests/test_fexerj_player.py
@@ -1,0 +1,46 @@
+"""Unit tests for the FexerjPlayer data class."""
+import pytest
+
+from classes import FexerjPlayer
+
+
+class TestFexerjPlayerInit:
+    def test_stores_all_attributes(self):
+        player = FexerjPlayer(
+            id_fexerj=42,
+            id_cbx="12345",
+            title="GM",
+            name="GARRY KASPAROV",
+            last_rating=2851,
+            club="FIDE",
+            birthday="13/04/1963",
+            sex="M",
+            federation="RUS",
+            total_games=200,
+            sum_opponents_ratings=500000,
+            points_against_opponents=130.0,
+        )
+        assert player.id_fexerj == 42
+        assert player.id_cbx == "12345"
+        assert player.title == "GM"
+        assert player.name == "GARRY KASPAROV"
+        assert player.last_rating == 2851
+        assert player.club == "FIDE"
+        assert player.birthday == "13/04/1963"
+        assert player.sex == "M"
+        assert player.federation == "RUS"
+        assert player.total_games == 200
+        assert player.sum_opponents_ratings == 500000
+        assert player.points_against_opponents == 130.0
+
+    def test_empty_optional_fields(self):
+        """id_cbx and title are often empty strings in the CSV."""
+        player = FexerjPlayer(1, "", "", "PLAYER NAME", 1000, "", "", "M", "BRA", 0, 0, 0.0)
+        assert player.id_cbx == ""
+        assert player.title == ""
+
+    def test_zero_games_unrated_player(self):
+        player = FexerjPlayer(99, "", "", "NEW PLAYER", 1000, "CLUB", "01/01/2005", "M", "BRA", 0, 0, 0.0)
+        assert player.total_games == 0
+        assert player.sum_opponents_ratings == 0
+        assert player.points_against_opponents == 0.0

--- a/old/tests/test_fexerj_rating_cycle.py
+++ b/old/tests/test_fexerj_rating_cycle.py
@@ -1,0 +1,117 @@
+"""Unit tests for FexerjRatingCycle."""
+import json
+import pytest
+
+from classes import FexerjRatingCycle, FexerjPlayer
+
+
+class TestFexerjRatingCycleInit:
+    def test_initial_state(self):
+        cycle = FexerjRatingCycle("tournaments.csv", 1, 10, "ratings.csv")
+        assert cycle.tournaments_file == "tournaments.csv"
+        assert cycle.first_item == 1
+        assert cycle.items_to_process == 10
+        assert cycle.initial_rating_filepath == "ratings.csv"
+        assert cycle.rating_list == {}
+        assert cycle.cbx_to_fexerj == {}
+        assert cycle.manual_entries == {}
+
+
+class TestGetRatingList:
+    def test_loads_all_players(self, rating_list_csv_path):
+        cycle = FexerjRatingCycle("t.csv", 1, 1, rating_list_csv_path)
+        cycle.get_rating_list(rating_list_csv_path)
+        assert len(cycle.rating_list) == 3
+
+    def test_player_attributes_parsed_correctly(self, rating_list_csv_path):
+        cycle = FexerjRatingCycle("t.csv", 1, 1, rating_list_csv_path)
+        cycle.get_rating_list(rating_list_csv_path)
+
+        player = cycle.rating_list[1]
+        assert isinstance(player, FexerjPlayer)
+        assert player.id_fexerj == 1
+        assert player.last_rating == 1500
+        assert player.total_games == 50
+        assert player.name == " JOSE DA SILVA"
+
+    def test_cbx_to_fexerj_mapping_built(self, rating_list_csv_path):
+        """Players with a CBX ID should appear in the cbx→fexerj mapping."""
+        cycle = FexerjRatingCycle("t.csv", 1, 1, rating_list_csv_path)
+        cycle.get_rating_list(rating_list_csv_path)
+        assert 36633 in cycle.cbx_to_fexerj
+        assert cycle.cbx_to_fexerj[36633] == 2
+
+    def test_players_without_cbx_not_in_mapping(self, rating_list_csv_path):
+        """Players with empty CBX ID should NOT appear in the mapping."""
+        cycle = FexerjRatingCycle("t.csv", 1, 1, rating_list_csv_path)
+        cycle.get_rating_list(rating_list_csv_path)
+        assert 1 not in cycle.cbx_to_fexerj
+
+    def test_temp_player_has_correct_stats(self, rating_list_csv_path):
+        """Verify partial-game stats for a temporary-rated player."""
+        cycle = FexerjRatingCycle("t.csv", 1, 1, rating_list_csv_path)
+        cycle.get_rating_list(rating_list_csv_path)
+        player = cycle.rating_list[3]
+        assert player.total_games == 5
+        assert player.sum_opponents_ratings == "30000"
+        assert player.points_against_opponents == "2.5"
+
+    def test_cbx_id_zero_is_mapped(self, tmp_path):
+        """CBX ID '0' has length > 0 so it is added to the mapping with key 0."""
+        csv_content = (
+            "Id_No;Id_CBX;Title;Name;Rtg_Nat;ClubName;Birthday;Sex;Fed;TotalNumGames;SumOpponRating;TotalPoints\n"
+            "5;0;;PLAYER ZERO;1400;CLUB;01/01/1990;M;BRA;20;0;0\n"
+        )
+        csv_file = tmp_path / "ratings.csv"
+        csv_file.write_text(csv_content)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, str(csv_file))
+        cycle.get_rating_list(str(csv_file))
+        assert 0 in cycle.cbx_to_fexerj
+        assert cycle.cbx_to_fexerj[0] == 5
+
+    def test_multiple_players_all_loaded(self, tmp_path):
+        """All rows in the CSV, regardless of CBX presence, must be in rating_list."""
+        csv_content = (
+            "Id_No;Id_CBX;Title;Name;Rtg_Nat;ClubName;Birthday;Sex;Fed;TotalNumGames;SumOpponRating;TotalPoints\n"
+            "10;;;PLAYER A;1500;C;01/01/1990;M;BRA;50;0;0\n"
+            "11;99;;PLAYER B;1600;C;01/01/1985;M;BRA;80;0;0\n"
+            "12;;;PLAYER C;1700;C;01/01/1980;M;BRA;0;0;0\n"
+        )
+        csv_file = tmp_path / "ratings.csv"
+        csv_file.write_text(csv_content)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, str(csv_file))
+        cycle.get_rating_list(str(csv_file))
+        assert set(cycle.rating_list.keys()) == {10, 11, 12}
+        assert cycle.cbx_to_fexerj == {99: 11}
+
+    def test_empty_csv_yields_empty_rating_list(self, tmp_path):
+        """A CSV with only the header and no data rows should produce an empty rating_list."""
+        csv_content = (
+            "Id_No;Id_CBX;Title;Name;Rtg_Nat;ClubName;Birthday;Sex;Fed;TotalNumGames;SumOpponRating;TotalPoints\n"
+        )
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text(csv_content)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, str(csv_file))
+        cycle.get_rating_list(str(csv_file))
+        assert cycle.rating_list == {}
+        assert cycle.cbx_to_fexerj == {}
+
+
+class TestManualEntryDict:
+    def test_load_when_file_missing(self, tmp_path, monkeypatch):
+        """load_manual_entry_dict should leave manual_entries empty when no file."""
+        monkeypatch.chdir(tmp_path)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
+        cycle.load_manual_entry_dict()
+        assert cycle.manual_entries == {}
+
+    def test_write_and_reload(self, tmp_path, monkeypatch):
+        """Writing then loading manual entries should round-trip correctly."""
+        monkeypatch.chdir(tmp_path)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
+        cycle.manual_entries = {"1.5": 999, "2.3": 888}
+        cycle.write_manual_entry_dict()
+
+        cycle2 = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
+        cycle2.load_manual_entry_dict()
+        assert cycle2.manual_entries == {"1.5": 999, "2.3": 888}

--- a/old/tests/test_tournament.py
+++ b/old/tests/test_tournament.py
@@ -1,0 +1,423 @@
+"""Unit tests for Tournament class methods.
+
+Uses the make_tournament and make_tournament_player fixtures from conftest.py.
+Network calls are patched out via load_player_page.
+"""
+import csv
+import pytest
+from unittest.mock import MagicMock, patch
+
+from classes import Tournament, TournamentPlayer, FexerjPlayer, _MAX_NUM_GAMES_TEMP_RATING, _AUDIT_FILE_HEADER
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fexerj_player(id_fexerj, total_games, last_rating, sum_oppon=0, pts_oppon=0.0, id_cbx=""):
+    return FexerjPlayer(id_fexerj, id_cbx, "", f"Player {id_fexerj}", last_rating,
+                        "CLUB", "01/01/1990", "M", "BRA", total_games, sum_oppon, pts_oppon)
+
+
+def _make_tp(tournament, fexerj_id, snr, opponents_list=None):
+    """Build a TournamentPlayer without HTTP, with opponents as a list (pre-complete_players_info format)."""
+    with patch.object(TournamentPlayer, "load_player_page"):
+        tp = TournamentPlayer(tournament, "http://fake")
+    tp.id = fexerj_id
+    tp.snr = snr
+    tp.name = f"Player {fexerj_id}"
+    tp.opponents = opponents_list if opponents_list is not None else []
+    tp.is_unrated = None
+    tp.is_temp = None
+    return tp
+
+
+def _make_tournament(is_irt=0, is_fexerj=1, rating_list=None, cbx_to_fexerj=None):
+    rc = MagicMock()
+    rc.rating_list = rating_list or {}
+    rc.cbx_to_fexerj = cbx_to_fexerj or {}
+    data = ["1", "12345", "Test Tournament", "2025-01-01", "SS", str(is_irt), str(is_fexerj)]
+    return Tournament(rc, data)
+
+
+# ---------------------------------------------------------------------------
+# complete_players_info
+# ---------------------------------------------------------------------------
+
+class TestCompletePlersInfo:
+    def test_unrated_player_classified(self):
+        fp = _make_fexerj_player(1, total_games=0, last_rating=0)
+        t = _make_tournament(rating_list={1: fp})
+        tp = _make_tp(t, fexerj_id=1, snr=1)
+        t.players = {1: tp}
+
+        t.complete_players_info()
+
+        assert tp.is_unrated is True
+        assert 1 in t.unrated_keys
+        assert 1 not in t.temp_keys
+        assert 1 not in t.established_keys
+
+    def test_temp_player_classified(self):
+        fp = _make_fexerj_player(2, total_games=5, last_rating=1200)
+        t = _make_tournament(rating_list={2: fp})
+        tp = _make_tp(t, fexerj_id=2, snr=2)
+        t.players = {2: tp}
+
+        t.complete_players_info()
+
+        assert tp.is_temp is True
+        assert 2 in t.temp_keys
+        assert 2 not in t.unrated_keys
+        assert 2 not in t.established_keys
+
+    def test_established_player_classified(self):
+        fp = _make_fexerj_player(3, total_games=_MAX_NUM_GAMES_TEMP_RATING, last_rating=1500)
+        t = _make_tournament(rating_list={3: fp})
+        tp = _make_tp(t, fexerj_id=3, snr=3)
+        t.players = {3: tp}
+
+        t.complete_players_info()
+
+        assert 3 in t.established_keys
+        assert 3 not in t.unrated_keys
+        assert 3 not in t.temp_keys
+
+    def test_player_attributes_copied_from_fexerj_player(self):
+        fp = _make_fexerj_player(4, total_games=50, last_rating=1700, sum_oppon=0, pts_oppon=0.0)
+        t = _make_tournament(rating_list={4: fp})
+        tp = _make_tp(t, fexerj_id=4, snr=4)
+        t.players = {4: tp}
+
+        t.complete_players_info()
+
+        assert tp.last_rating == 1700
+        assert tp.last_total_games == 50
+
+    def test_boundary_exactly_15_games_is_established(self):
+        fp = _make_fexerj_player(5, total_games=15, last_rating=1400)
+        t = _make_tournament(rating_list={5: fp})
+        tp = _make_tp(t, fexerj_id=5, snr=5)
+        t.players = {5: tp}
+
+        t.complete_players_info()
+
+        assert 5 in t.established_keys
+
+    def test_boundary_14_games_is_temp(self):
+        fp = _make_fexerj_player(6, total_games=14, last_rating=1400)
+        t = _make_tournament(rating_list={6: fp})
+        tp = _make_tp(t, fexerj_id=6, snr=6)
+        t.players = {6: tp}
+
+        t.complete_players_info()
+
+        assert 6 in t.temp_keys
+
+    def test_opponents_converted_from_list_to_dict(self):
+        """After complete_players_info, tp.opponents must be a dict keyed by SNR."""
+        fp1 = _make_fexerj_player(1, total_games=50, last_rating=1500)
+        fp2 = _make_fexerj_player(2, total_games=50, last_rating=1600)
+        t = _make_tournament(rating_list={1: fp1, 2: fp2})
+
+        tp1 = _make_tp(t, fexerj_id=1, snr=1, opponents_list=[[2, "Player 2", 1.0]])
+        tp2 = _make_tp(t, fexerj_id=2, snr=2, opponents_list=[[1, "Player 1", 0.0]])
+        t.players = {1: tp1, 2: tp2}
+
+        t.complete_players_info()
+
+        assert isinstance(tp1.opponents, dict)
+        assert 2 in tp1.opponents
+        assert tp1.opponents[2][0] is tp2   # points to the actual TournamentPlayer object
+        assert tp1.opponents[2][1] == 1.0   # score preserved
+
+    def test_irt_tournament_uses_cbx_to_fexerj_mapping(self):
+        """In IRT tournaments, player lookup goes through cbx_to_fexerj."""
+        fp = _make_fexerj_player(10, total_games=50, last_rating=1800)
+        t = _make_tournament(is_irt=1, rating_list={10: fp}, cbx_to_fexerj={99: 10})
+        tp = _make_tp(t, fexerj_id=99, snr=1)  # tp.id is CBX id
+        t.players = {1: tp}
+
+        t.complete_players_info()
+
+        assert tp.last_rating == 1800
+        assert tp.last_total_games == 50
+
+    def test_all_player_types_classified_together(self):
+        """Unrated, temp, and established players are correctly classified in a single call."""
+        fp_unrated = _make_fexerj_player(1, total_games=0,  last_rating=0)
+        fp_temp    = _make_fexerj_player(2, total_games=5,  last_rating=1200)
+        fp_estab   = _make_fexerj_player(3, total_games=50, last_rating=1500)
+        t = _make_tournament(rating_list={1: fp_unrated, 2: fp_temp, 3: fp_estab})
+
+        tp1 = _make_tp(t, fexerj_id=1, snr=1)
+        tp2 = _make_tp(t, fexerj_id=2, snr=2)
+        tp3 = _make_tp(t, fexerj_id=3, snr=3)
+        t.players = {1: tp1, 2: tp2, 3: tp3}
+
+        t.complete_players_info()
+
+        assert t.unrated_keys    == [1]
+        assert t.temp_keys       == [2]
+        assert t.established_keys == [3]
+        assert tp1.is_unrated is True
+        assert tp2.is_temp    is True
+
+
+# ---------------------------------------------------------------------------
+# write_tournament_audit
+# ---------------------------------------------------------------------------
+
+def _make_calculated_tp(tournament, fexerj_id=100, last_rating=1500, last_total_games=50,
+                         last_k=15, this_pts=1.0, this_games=1, this_sum_oppon=1500,
+                         this_avg_oppon=1500.0, this_expected=0.5, this_points_above=0.5,
+                         new_rating=1508, new_total_games=51, calc_rule="NORMAL"):
+    """Build a TournamentPlayer with all post-calculation attributes set."""
+    with patch.object(TournamentPlayer, "load_player_page"):
+        tp = TournamentPlayer(tournament, "http://fake")
+    tp.id = fexerj_id
+    tp.name = f"Player {fexerj_id}"
+    tp.last_rating = last_rating
+    tp.last_total_games = last_total_games
+    tp.last_k = last_k
+    tp.this_pts_against_oppon = this_pts
+    tp.this_games = this_games
+    tp.this_sum_oppon_ratings = this_sum_oppon
+    tp.this_avg_oppon_rating = this_avg_oppon
+    tp.this_expected_points = this_expected
+    tp.this_points_above_expected = this_points_above
+    tp.new_rating = new_rating
+    tp.new_total_games = new_total_games
+    tp.calc_rule = calc_rule
+    return tp
+
+
+class TestWriteTournamentAudit:
+    def test_header_is_written(self, tmp_path):
+        t = _make_tournament()
+        t.players = {}
+        output = str(tmp_path / "audit.csv")
+
+        t.write_tournament_audit(output)
+
+        with open(output) as f:
+            first_line = f.readline().strip()
+        assert first_line == _AUDIT_FILE_HEADER
+
+    def test_one_line_per_player(self, tmp_path):
+        t = _make_tournament()
+        t.players = {
+            1: _make_calculated_tp(t, fexerj_id=101),
+            2: _make_calculated_tp(t, fexerj_id=102),
+        }
+        output = str(tmp_path / "audit.csv")
+
+        t.write_tournament_audit(output)
+
+        with open(output) as f:
+            lines = [l for l in f.read().splitlines() if l]
+        assert len(lines) == 3  # header + 2 player lines
+
+    def test_correct_number_of_fields_per_line(self, tmp_path):
+        """Each data line must have exactly 19 semicolon-separated fields."""
+        t = _make_tournament()
+        t.players = {1: _make_calculated_tp(t)}
+        output = str(tmp_path / "audit.csv")
+
+        t.write_tournament_audit(output)
+
+        with open(output) as f:
+            lines = f.read().splitlines()
+        data_line = lines[1]
+        assert len(data_line.split(";")) == 19
+
+    def test_player_values_in_output(self, tmp_path):
+        """Key player values should appear in the audit line."""
+        t = _make_tournament()
+        t.players = {1: _make_calculated_tp(t, fexerj_id=100, new_rating=1508, calc_rule="NORMAL")}
+        output = str(tmp_path / "audit.csv")
+
+        t.write_tournament_audit(output)
+
+        with open(output) as f:
+            content = f.read()
+        assert "1508" in content
+        assert "NORMAL" in content
+        assert "100" in content
+
+    def test_zero_games_player_we_and_p_are_none(self, tmp_path):
+        """When this_games == 0, We and P columns must be 'None'."""
+        t = _make_tournament()
+        tp = _make_calculated_tp(t, this_games=0, this_pts=None,
+                                  this_sum_oppon=None, this_avg_oppon=None,
+                                  this_expected=None, this_points_above=None,
+                                  new_rating=1500, new_total_games=50, calc_rule=None)
+        t.players = {1: tp}
+        output = str(tmp_path / "audit.csv")
+
+        t.write_tournament_audit(output)
+
+        with open(output) as f:
+            reader = csv.reader(f, delimiter=";")
+            next(reader)  # skip header
+            row = next(reader)
+        # We is column index 11, P is column index 17
+        assert row[11] == "None"
+        assert row[17] == "None"
+
+
+# ---------------------------------------------------------------------------
+# write_new_ratings_list
+# ---------------------------------------------------------------------------
+
+class TestWriteNewRatingsList:
+    def _setup(self, new_total_games):
+        fp = _make_fexerj_player(100, total_games=50, last_rating=1500)
+        t = _make_tournament(rating_list={100: fp})
+        with patch.object(TournamentPlayer, "load_player_page"):
+            tp = TournamentPlayer(t, "http://fake")
+        tp.id = 100
+        tp.new_rating = 1520
+        tp.new_total_games = new_total_games
+        tp.new_sum_oppon_ratings = 3000
+        tp.new_pts_against_oppon = 2.0
+        t.players = {1: tp}
+        return t, fp
+
+    def test_fexerj_player_rating_updated(self, tmp_path):
+        t, fp = self._setup(new_total_games=51)
+        t.write_new_ratings_list(str(tmp_path / "out.csv"))
+        assert fp.last_rating == 1520
+        assert fp.total_games == 51
+
+    def test_established_player_stats_reset_to_zero(self, tmp_path):
+        """Players with >= 15 new games have sum_opponents_ratings and points reset."""
+        t, fp = self._setup(new_total_games=51)
+        t.write_new_ratings_list(str(tmp_path / "out.csv"))
+        assert fp.sum_opponents_ratings == 0
+        assert fp.points_against_opponents == 0
+
+    def test_temp_player_stats_preserved(self, tmp_path):
+        """Players with < 15 new games retain sum_opponents_ratings and points."""
+        t, fp = self._setup(new_total_games=8)
+        t.write_new_ratings_list(str(tmp_path / "out.csv"))
+        assert fp.sum_opponents_ratings == 3000
+        assert fp.points_against_opponents == 2.0
+
+    def test_output_file_has_header(self, tmp_path):
+        t, _ = self._setup(new_total_games=51)
+        output = str(tmp_path / "out.csv")
+        t.write_new_ratings_list(output)
+        with open(output) as f:
+            first_line = f.readline().strip()
+        assert first_line.startswith("Id_No")
+
+    def test_output_file_contains_new_rating(self, tmp_path):
+        t, _ = self._setup(new_total_games=51)
+        output = str(tmp_path / "out.csv")
+        t.write_new_ratings_list(output)
+        with open(output) as f:
+            content = f.read()
+        assert "1520" in content
+
+    def test_boundary_exactly_15_new_games_resets_stats(self, tmp_path):
+        """new_total_games == 15 is >= _MAX_NUM_GAMES_TEMP_RATING → stats must be reset."""
+        t, fp = self._setup(new_total_games=15)
+        t.write_new_ratings_list(str(tmp_path / "out.csv"))
+        assert fp.sum_opponents_ratings == 0
+        assert fp.points_against_opponents == 0
+
+    def test_boundary_14_new_games_preserves_stats(self, tmp_path):
+        """new_total_games == 14 is < _MAX_NUM_GAMES_TEMP_RATING → stats must be kept."""
+        t, fp = self._setup(new_total_games=14)
+        t.write_new_ratings_list(str(tmp_path / "out.csv"))
+        assert fp.sum_opponents_ratings == 3000
+        assert fp.points_against_opponents == 2.0
+
+
+# ---------------------------------------------------------------------------
+# calculate_players_ratings — processing order
+# ---------------------------------------------------------------------------
+
+class TestCalculatePlayersRatings:
+    def test_unrated_processed_before_established(self):
+        """Unrated players must be processed first so their new_rating is available
+        when established players reference them as opponents."""
+        t = _make_tournament()
+
+        fp_unrated = _make_fexerj_player(1, total_games=0, last_rating=0)
+        fp_established = _make_fexerj_player(2, total_games=50, last_rating=1500)
+        t.rating_cycle.rating_list = {1: fp_unrated, 2: fp_established}
+
+        # Build players with opponents already in dict format (post complete_players_info)
+        with patch.object(TournamentPlayer, "load_player_page"):
+            tp_unrated = TournamentPlayer(t, "http://fake")
+        tp_unrated.id = 1
+        tp_unrated.name = "Unrated"
+        tp_unrated.is_unrated = True
+        tp_unrated.is_temp = False
+        tp_unrated.last_rating = 0
+        tp_unrated.last_total_games = 0
+        tp_unrated.last_sum_oppon_ratings = 0
+        tp_unrated.last_pts_against_oppon = 0.0
+
+        with patch.object(TournamentPlayer, "load_player_page"):
+            tp_established = TournamentPlayer(t, "http://fake")
+        tp_established.id = 2
+        tp_established.name = "Established"
+        tp_established.is_unrated = False
+        tp_established.is_temp = False
+        tp_established.last_rating = 1500
+        tp_established.last_total_games = 50
+        tp_established.last_sum_oppon_ratings = 0
+        tp_established.last_pts_against_oppon = 0.0
+
+        # Unrated beats established; established loses to unrated
+        tp_unrated.opponents = {2: [tp_established, 1.0]}
+        tp_established.opponents = {1: [tp_unrated, 0.0]}
+
+        t.players = {1: tp_unrated, 2: tp_established}
+        t.unrated_keys = [1]
+        t.temp_keys = []
+        t.established_keys = [2]
+
+        t.calculate_players_ratings()
+
+        # Unrated player's new_rating must be set before established player ran
+        assert tp_unrated.new_rating is not None
+        assert tp_unrated.new_rating > 0
+        # Established player must have used unrated player's new_rating (not last_rating=0)
+        assert tp_established.this_sum_oppon_ratings == tp_unrated.new_rating
+
+    def test_all_player_types_are_processed(self):
+        """All players (unrated, temp, established) must have new_rating set after the call."""
+        t = _make_tournament()
+
+        def _build_tp(fexerj_id, is_unrated, is_temp, last_rating, last_total_games):
+            with patch.object(TournamentPlayer, "load_player_page"):
+                tp = TournamentPlayer(t, "http://fake")
+            tp.id = fexerj_id
+            tp.name = f"P{fexerj_id}"
+            tp.is_unrated = is_unrated
+            tp.is_temp = is_temp
+            tp.last_rating = last_rating
+            tp.last_total_games = last_total_games
+            tp.last_sum_oppon_ratings = 0
+            tp.last_pts_against_oppon = 0.0
+            tp.opponents = {}   # no opponents → keep_current_rating
+            return tp
+
+        tp1 = _build_tp(1, is_unrated=True,  is_temp=False, last_rating=0,    last_total_games=0)
+        tp2 = _build_tp(2, is_unrated=False, is_temp=True,  last_rating=1200, last_total_games=5)
+        tp3 = _build_tp(3, is_unrated=False, is_temp=False, last_rating=1500, last_total_games=50)
+
+        t.players = {1: tp1, 2: tp2, 3: tp3}
+        t.unrated_keys = [1]
+        t.temp_keys = [2]
+        t.established_keys = [3]
+
+        t.calculate_players_ratings()
+
+        assert tp1.new_rating is not None
+        assert tp2.new_rating is not None
+        assert tp3.new_rating is not None

--- a/old/tests/test_tournament_player.py
+++ b/old/tests/test_tournament_player.py
@@ -1,0 +1,646 @@
+"""Unit tests for TournamentPlayer pure-logic methods.
+
+All tests avoid network calls by patching load_player_page via the
+make_tournament_player factory fixture defined in conftest.py.
+"""
+import math
+import pytest
+
+from classes import TournamentPlayer, _MAX_NUM_GAMES_TEMP_RATING
+
+
+# ---------------------------------------------------------------------------
+# add_opponent
+# ---------------------------------------------------------------------------
+
+class TestAddOpponent:
+    def test_win_added(self, make_tournament_player):
+        p = make_tournament_player(opponents=[])
+        p.add_opponent(5, "Opponent A", "1")
+        assert len(p.opponents) == 1
+        assert p.opponents[0] == [5, "Opponent A", 1.0]
+
+    def test_draw_added(self, make_tournament_player):
+        p = make_tournament_player(opponents=[])
+        p.add_opponent(3, "Opponent B", "½")
+        assert p.opponents[0][2] == 0.5
+
+    def test_loss_added(self, make_tournament_player):
+        p = make_tournament_player(opponents=[])
+        p.add_opponent(7, "Opponent C", "0")
+        assert p.opponents[0][2] == 0.0
+
+    def test_forfeit_ignored(self, make_tournament_player):
+        """Results ending in 'K' (forfeit/absent) must not be stored."""
+        p = make_tournament_player(opponents=[])
+        p.add_opponent(2, "Opponent D", "1K")
+        assert len(p.opponents) == 0
+
+    def test_multiple_opponents(self, make_tournament_player):
+        p = make_tournament_player(opponents=[])
+        p.add_opponent(1, "A", "1")
+        p.add_opponent(2, "B", "½")
+        p.add_opponent(3, "C", "0")
+        assert len(p.opponents) == 3
+
+
+# ---------------------------------------------------------------------------
+# keep_current_rating
+# ---------------------------------------------------------------------------
+
+class TestKeepCurrentRating:
+    def test_copies_last_values(self, make_tournament_player):
+        p = make_tournament_player(
+            last_rating=1600,
+            last_total_games=30,
+            last_sum_oppon_ratings=48000,
+            last_pts_against_oppon=15.5,
+        )
+        p.keep_current_rating()
+        assert p.new_rating == 1600
+        assert p.new_total_games == 30
+        assert p.new_sum_oppon_ratings == 48000
+        assert p.new_pts_against_oppon == 15.5
+
+
+# ---------------------------------------------------------------------------
+# get_current_k
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentK:
+    """K-factor lookup based on total games played.
+
+    _K_STARTING_NUM_GAMES = [(30, 0), (25, 15), (15, 40), (10, 80)]
+    The loop keeps overwriting current_k as long as last_total_games >= threshold,
+    so the last matching entry wins.
+    """
+
+    def test_grampo_range(self, make_tournament_player):
+        """0–14 games → k=30 (grampo)."""
+        for games in [0, 1, 14]:
+            p = make_tournament_player(last_total_games=games)
+            assert p.get_current_k() == 30, f"expected k=30 for {games} games"
+
+    def test_entry_at_15_games(self, make_tournament_player):
+        p = make_tournament_player(last_total_games=_MAX_NUM_GAMES_TEMP_RATING)
+        assert p.get_current_k() == 25
+
+    def test_mid_range_25(self, make_tournament_player):
+        """15–39 games → k=25."""
+        p = make_tournament_player(last_total_games=39)
+        assert p.get_current_k() == 25
+
+    def test_entry_at_40_games(self, make_tournament_player):
+        p = make_tournament_player(last_total_games=40)
+        assert p.get_current_k() == 15
+
+    def test_mid_range_15(self, make_tournament_player):
+        """40–79 games → k=15."""
+        p = make_tournament_player(last_total_games=79)
+        assert p.get_current_k() == 15
+
+    def test_entry_at_80_games(self, make_tournament_player):
+        p = make_tournament_player(last_total_games=80)
+        assert p.get_current_k() == 10
+
+    def test_large_game_count(self, make_tournament_player):
+        """High game counts still return k=10."""
+        p = make_tournament_player(last_total_games=500)
+        assert p.get_current_k() == 10
+
+
+# ---------------------------------------------------------------------------
+# get_performance_rating
+# ---------------------------------------------------------------------------
+
+class TestGetPerformanceRating:
+    """get_performance_rating(avg_oppon_rating, num_valid_games, total_num_points)"""
+
+    def test_even_score_equals_average(self, make_tournament_player):
+        """50 % score → performance equals average opponent rating."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 4, 2.0)
+        assert abs(result - 1500) < 0.01
+
+    def test_perfect_score_adjusted(self, make_tournament_player):
+        """Perfect score is adjusted to avoid infinity."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 4, 4.0)
+        # score adjusted to 4.5/5 = 0.9
+        expected = 1500 + 400 * math.log10(0.9 / 0.1)
+        assert abs(result - expected) < 0.01
+
+    def test_zero_score_adjusted(self, make_tournament_player):
+        """Zero score is adjusted to avoid negative infinity."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 4, 0.0)
+        # score adjusted to 0.5/5 = 0.1
+        expected = 1500 + 400 * math.log10(0.1 / 0.9)
+        assert abs(result - expected) < 0.01
+
+    def test_above_average_score_raises_rating(self, make_tournament_player):
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 4, 3.0)
+        assert result > 1500
+
+    def test_below_average_score_lowers_rating(self, make_tournament_player):
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 4, 1.0)
+        assert result < 1500
+
+    def test_single_game_win(self, make_tournament_player):
+        """1 game, 1 point → perfect score → adjusted."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1600, 1, 1.0)
+        # adjusted score = 1.5/2 = 0.75
+        expected = 1600 + 400 * math.log10(0.75 / 0.25)
+        assert abs(result - expected) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# check_rating_performance_rule
+# ---------------------------------------------------------------------------
+
+class TestCheckRatingPerformanceRule:
+    def test_fewer_than_5_games_always_false(self, make_tournament_player):
+        for games in range(0, 5):
+            p = make_tournament_player()
+            p.this_games = games
+            p.this_points_above_expected = 999.0
+            assert p.check_rating_performance_rule() is False
+
+    def test_5_games_below_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 5
+        p.this_points_above_expected = 1.83
+        assert p.check_rating_performance_rule() is False
+
+    def test_5_games_at_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 5
+        p.this_points_above_expected = 1.84
+        assert p.check_rating_performance_rule() is True
+
+    def test_5_games_above_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 5
+        p.this_points_above_expected = 2.0
+        assert p.check_rating_performance_rule() is True
+
+    def test_6_games_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 6
+        p.this_points_above_expected = 2.02
+        assert p.check_rating_performance_rule() is True
+
+    def test_6_games_below_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 6
+        p.this_points_above_expected = 2.01
+        assert p.check_rating_performance_rule() is False
+
+    def test_7_games_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 7
+        p.this_points_above_expected = 2.16
+        assert p.check_rating_performance_rule() is True
+
+    def test_more_than_7_games_returns_false(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 8
+        p.this_points_above_expected = 999.0
+        assert p.check_rating_performance_rule() is False
+
+
+# ---------------------------------------------------------------------------
+# check_double_k_rule
+# ---------------------------------------------------------------------------
+
+class TestCheckDoubleKRule:
+    def test_fewer_than_4_games_always_false(self, make_tournament_player):
+        for games in range(0, 4):
+            p = make_tournament_player()
+            p.this_games = games
+            p.this_points_above_expected = 999.0
+            assert p.check_double_k_rule() is False
+
+    def test_4_games_at_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 4
+        p.this_points_above_expected = 1.65
+        assert p.check_double_k_rule() is True
+
+    def test_4_games_below_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 4
+        p.this_points_above_expected = 1.64
+        assert p.check_double_k_rule() is False
+
+    def test_5_games_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 5
+        p.this_points_above_expected = 1.43
+        assert p.check_double_k_rule() is True
+
+    def test_6_games_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 6
+        p.this_points_above_expected = 1.56
+        assert p.check_double_k_rule() is True
+
+    def test_7_games_threshold(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 7
+        p.this_points_above_expected = 1.69
+        assert p.check_double_k_rule() is True
+
+    def test_more_than_7_games_returns_false(self, make_tournament_player):
+        p = make_tournament_player()
+        p.this_games = 8
+        p.this_points_above_expected = 999.0
+        assert p.check_double_k_rule() is False
+
+
+# ---------------------------------------------------------------------------
+# get_calculation_rule
+# ---------------------------------------------------------------------------
+
+class TestGetCalculationRule:
+    def test_temporary_player_returns_temporary(self, make_tournament_player):
+        p = make_tournament_player(is_temp=True, is_unrated=False)
+        p.this_games = 5
+        p.this_points_above_expected = 0.0
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "TEMPORARY"
+
+    def test_unrated_player_returns_temporary(self, make_tournament_player):
+        p = make_tournament_player(is_temp=False, is_unrated=True)
+        p.this_games = 5
+        p.this_points_above_expected = 0.0
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "TEMPORARY"
+
+    def test_rating_performance_in_fexerj_tournament(self, make_tournament_player):
+        """RP rule requires is_fexerj=True and check_rating_performance_rule()=True."""
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        p.this_games = 5
+        p.this_points_above_expected = 1.84  # triggers RP rule
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "RATING_PERFORMANCE"
+
+    def test_rating_performance_not_applied_outside_fexerj(self, make_tournament_player):
+        """RP rule must NOT apply when is_fexerj=False."""
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        p.this_games = 5
+        p.this_points_above_expected = 1.84
+        rule = p.get_calculation_rule(is_fexerj_tournament=False)
+        assert rule != "RATING_PERFORMANCE"
+
+    def test_double_k_rule(self, make_tournament_player):
+        """Double-K triggers when RP rule doesn't but DK condition met."""
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        p.this_games = 4
+        p.this_points_above_expected = 1.65  # triggers DK, but not RP (< 5 games)
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "DOUBLE_K"
+
+    def test_normal_rule(self, make_tournament_player):
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        p.this_games = 4
+        p.this_points_above_expected = 0.0
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "NORMAL"
+
+
+# ---------------------------------------------------------------------------
+# calculate_new_rating — integration of pure logic
+# ---------------------------------------------------------------------------
+
+class TestCalculateNewRating:
+    """Tests for calculate_new_rating using mock opponent TournamentPlayer objects."""
+
+    def _make_opponent(self, make_tournament_player, **kwargs):
+        """Build a minimal opponent player."""
+        return make_tournament_player(**kwargs)
+
+    def test_no_opponents_keeps_rating(self, make_tournament_player):
+        p = make_tournament_player(
+            last_rating=1500, last_total_games=50, opponents={},
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating == 1500
+        assert p.new_total_games == 50
+
+    def test_established_player_win_increases_rating(self, make_tournament_player):
+        """Winning against same-rated opponents should increase an established player's rating."""
+        opp = self._make_opponent(make_tournament_player, last_rating=1500,
+                                  new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1500, last_total_games=50,
+            opponents={1: [opp, 1.0]},  # win
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating > 1500
+
+    def test_established_player_loss_decreases_rating(self, make_tournament_player):
+        opp = self._make_opponent(make_tournament_player, last_rating=1500,
+                                  new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1500, last_total_games=50,
+            opponents={1: [opp, 0.0]},  # loss
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating < 1500
+
+    def test_rating_never_below_one(self, make_tournament_player):
+        """New rating must be >= 1 even after a catastrophic loss."""
+        opp = self._make_opponent(make_tournament_player, last_rating=1,
+                                  new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1, last_total_games=50,
+            opponents={1: [opp, 0.0]},
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating >= 1
+
+    def test_unrated_opponent_excluded_for_unrated_player(self, make_tournament_player):
+        """An unrated player's unrated opponent with no new_rating should be excluded."""
+        opp_unrated = self._make_opponent(make_tournament_player, last_rating=0,
+                                          new_rating=None, is_unrated=True, is_temp=False)
+        p = make_tournament_player(
+            last_rating=0, last_total_games=0,
+            opponents={1: [opp_unrated, 1.0]},
+            is_unrated=True, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        # All opponents removed → should keep current rating
+        assert p.new_rating == 0
+
+    def test_temp_player_rating_accumulates(self, make_tournament_player):
+        """Temporary player should accumulate stats and compute performance rating."""
+        opp = self._make_opponent(make_tournament_player, last_rating=1400,
+                                  new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1350, last_total_games=5,
+            last_sum_oppon_ratings=7000, last_pts_against_oppon=3.0,
+            opponents={1: [opp, 1.0]},
+            is_unrated=False, is_temp=True,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating is not None
+        assert p.new_total_games == 6
+        assert p.calc_rule == "TEMPORARY"
+
+    def test_calc_rule_set_after_calculation(self, make_tournament_player):
+        opp = self._make_opponent(make_tournament_player, last_rating=1500,
+                                  new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1500, last_total_games=50,
+            opponents={1: [opp, 0.5]},
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=True)
+        assert p.calc_rule in {"NORMAL", "DOUBLE_K", "RATING_PERFORMANCE"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_new_rating — exact formula verification per calc_rule path
+# ---------------------------------------------------------------------------
+
+class TestCalculateNewRatingPaths:
+    """Verify the exact rating computation for each calc_rule path."""
+
+    def _opp(self, make_tournament_player, **kwargs):
+        return make_tournament_player(**kwargs)
+
+    def test_normal_rule_exact_gain(self, make_tournament_player):
+        """NORMAL: gain = k * points_above_expected, rounded to nearest int."""
+        # 4 opponents at 1500, player at 1500, scores 3/4
+        # k=15 (50 games), expected=2.0, points_above=1.0 → gain=15 → new=1515
+        opps = {i: [self._opp(make_tournament_player, last_rating=1500,
+                              new_rating=None, is_unrated=False, is_temp=False), score]
+                for i, score in enumerate([1.0, 1.0, 1.0, 0.0], start=1)}
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents=opps, is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.calc_rule == "NORMAL"
+        assert p.new_rating == 1515
+
+    def test_double_k_exact_gain(self, make_tournament_player):
+        """DOUBLE_K: gain = 2 * k * points_above_expected."""
+        # 4 opponents at 1500, scores 4/4
+        # k=15, expected=2.0, points_above=2.0 → gain=2*15*2=60 → new=1560
+        opps = {i: [self._opp(make_tournament_player, last_rating=1500,
+                              new_rating=None, is_unrated=False, is_temp=False), 1.0]
+                for i in range(1, 5)}
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents=opps, is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.calc_rule == "DOUBLE_K"
+        assert p.new_rating == 1560
+
+    def test_double_k_gain_is_exactly_double_normal_gain(self, make_tournament_player):
+        """Under identical points_above_expected, DOUBLE_K gain is exactly 2× NORMAL."""
+        def _run(score_list, is_fexerj):
+            opps = {i: [self._opp(make_tournament_player, last_rating=1500,
+                                  new_rating=None, is_unrated=False, is_temp=False), s]
+                    for i, s in enumerate(score_list, start=1)}
+            p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                       opponents=opps, is_unrated=False, is_temp=False)
+            p.calculate_new_rating(is_fexerj_tournament=is_fexerj)
+            return p
+
+        normal = _run([1.0, 1.0, 1.0, 0.0], is_fexerj=False)   # 3/4 → NORMAL
+        double = _run([1.0, 1.0, 1.0, 1.0], is_fexerj=False)   # 4/4 → DOUBLE_K
+        assert normal.calc_rule == "NORMAL"
+        assert double.calc_rule == "DOUBLE_K"
+        normal_gain = normal.new_rating - 1500
+        double_gain = double.new_rating - 1500
+        assert double_gain == 2 * double.last_k * round(double.this_points_above_expected * 2) / 2
+        assert double_gain > normal_gain
+
+    def test_rating_performance_exact_formula(self, make_tournament_player):
+        """RATING_PERFORMANCE: new = round(last + (performance - last) / 2)."""
+        # 5 opponents at 1500, all wins → RP rule in FEXERJ tournament
+        opps = {i: [self._opp(make_tournament_player, last_rating=1500,
+                              new_rating=None, is_unrated=False, is_temp=False), 1.0]
+                for i in range(1, 6)}
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents=opps, is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=True)
+        assert p.calc_rule == "RATING_PERFORMANCE"
+        performance = p.get_performance_rating(1500, 5, 5.0)
+        expected_new = round(1500 + (performance - 1500) / 2)
+        assert p.new_rating == expected_new
+
+    def test_unrated_player_with_positive_score_gets_new_rating(self, make_tournament_player):
+        """Unrated player who wins should receive a performance-based new rating."""
+        opp = self._opp(make_tournament_player, last_rating=1500,
+                        new_rating=None, is_unrated=False, is_temp=False)
+        p = make_tournament_player(last_rating=0, last_total_games=0,
+                                   last_sum_oppon_ratings=0, last_pts_against_oppon=0.0,
+                                   opponents={1: [opp, 1.0]},
+                                   is_unrated=True, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.new_rating is not None
+        assert p.new_rating > 0
+        assert p.new_total_games == 1
+        assert p.calc_rule == "TEMPORARY"
+
+
+# ---------------------------------------------------------------------------
+# calculate_new_rating — opponent rating source selection
+# ---------------------------------------------------------------------------
+
+class TestOpponentRatingSelection:
+    """Verify which rating value (last_rating vs new_rating) is used per opponent type."""
+
+    def test_established_vs_unrated_opponent_uses_new_rating(self, make_tournament_player):
+        """Unrated opponent's new_rating is used when it is set and non-zero."""
+        opp = make_tournament_player(last_rating=0, new_rating=1000,
+                                     is_unrated=True, is_temp=False)
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents={1: [opp, 0.5]},
+                                   is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1000
+
+    def test_established_vs_temp_opponent_uses_new_rating(self, make_tournament_player):
+        """Temp opponent's new_rating is used when self is established."""
+        opp = make_tournament_player(last_rating=1300, new_rating=1350,
+                                     is_unrated=False, is_temp=True)
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents={1: [opp, 0.5]},
+                                   is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1350
+
+    def test_established_vs_established_opponent_uses_last_rating(self, make_tournament_player):
+        """Established opponent's last_rating is used, not new_rating."""
+        opp = make_tournament_player(last_rating=1600, new_rating=1700,
+                                     is_unrated=False, is_temp=False)
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents={1: [opp, 0.5]},
+                                   is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1600
+
+    def test_unrated_opponent_excluded_when_new_rating_is_zero(self, make_tournament_player):
+        """Unrated opponent with new_rating == 0 is excluded from calculation."""
+        opp = make_tournament_player(last_rating=0, new_rating=0,
+                                     is_unrated=True, is_temp=False)
+        p = make_tournament_player(last_rating=1500, last_total_games=50,
+                                   opponents={1: [opp, 1.0]},
+                                   is_unrated=False, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        # Opponent excluded → no games → keeps current rating
+        assert p.new_rating == 1500
+
+    def test_temp_vs_temp_uses_last_rating(self, make_tournament_player):
+        """When both self and opponent are temp, the else branch applies → last_rating used."""
+        opp = make_tournament_player(last_rating=1300, new_rating=1350,
+                                     is_unrated=False, is_temp=True)
+        p = make_tournament_player(last_rating=1200, last_total_games=5,
+                                   last_sum_oppon_ratings=0, last_pts_against_oppon=0.0,
+                                   opponents={1: [opp, 0.5]},
+                                   is_unrated=False, is_temp=True)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1300
+
+    def test_temp_vs_established_uses_last_rating(self, make_tournament_player):
+        """Temp player vs established opponent: else branch applies → last_rating used."""
+        opp = make_tournament_player(last_rating=1600, new_rating=1700,
+                                     is_unrated=False, is_temp=False)
+        p = make_tournament_player(last_rating=1200, last_total_games=5,
+                                   last_sum_oppon_ratings=0, last_pts_against_oppon=0.0,
+                                   opponents={1: [opp, 0.5]},
+                                   is_unrated=False, is_temp=True)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1600
+
+    def test_unrated_vs_established_uses_last_rating(self, make_tournament_player):
+        """Unrated player vs established opponent: else branch applies → last_rating used."""
+        opp = make_tournament_player(last_rating=1500, new_rating=1600,
+                                     is_unrated=False, is_temp=False)
+        p = make_tournament_player(last_rating=0, last_total_games=0,
+                                   last_sum_oppon_ratings=0, last_pts_against_oppon=0.0,
+                                   opponents={1: [opp, 1.0]},
+                                   is_unrated=True, is_temp=False)
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 1500
+
+
+# ---------------------------------------------------------------------------
+# calculate_new_rating — multiple mixed-type opponents in one game
+# ---------------------------------------------------------------------------
+
+class TestMixedOpponentSum:
+    """Verify the opponent rating sum is correct when facing multiple opponent types."""
+
+    def test_sum_uses_correct_rating_per_opponent_type(self, make_tournament_player):
+        """Established player facing unrated (new=1200), temp (new=1350), and
+        established (last=1600) opponents: sum must be 1200 + 1350 + 1600 = 4150."""
+        opp_unrated = make_tournament_player(last_rating=0, new_rating=1200,
+                                             is_unrated=True, is_temp=False)
+        opp_temp = make_tournament_player(last_rating=1300, new_rating=1350,
+                                          is_unrated=False, is_temp=True)
+        opp_estab = make_tournament_player(last_rating=1600, new_rating=1700,
+                                           is_unrated=False, is_temp=False)
+        p = make_tournament_player(
+            last_rating=1500, last_total_games=50,
+            opponents={
+                1: [opp_unrated, 1.0],
+                2: [opp_temp,    1.0],
+                3: [opp_estab,   0.0],
+            },
+            is_unrated=False, is_temp=False,
+        )
+        p.calculate_new_rating(is_fexerj_tournament=False)
+        assert p.this_sum_oppon_ratings == 4150
+        assert p.this_games == 3
+
+
+# ---------------------------------------------------------------------------
+# get_performance_rating — additional edge case
+# ---------------------------------------------------------------------------
+
+class TestGetPerformanceRatingEdgeCases:
+    def test_draw_score_no_adjustment(self, make_tournament_player):
+        """Score of exactly 0.5 requires no adjustment and returns avg opponent rating."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 2, 1.0)  # 1/2 = 0.5
+        assert abs(result - 1500) < 0.01
+
+    def test_perfect_score_single_game_adjustment(self, make_tournament_player):
+        """Score of 1.0 with 1 game: adjusted to 1.5/2=0.75, not infinity."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 1, 1.0)
+        assert math.isfinite(result)
+        assert result > 1500
+
+    def test_zero_score_single_game_adjustment(self, make_tournament_player):
+        """Score of 0.0 with 1 game: adjusted to 0.5/2=0.25, not negative infinity."""
+        p = make_tournament_player()
+        result = p.get_performance_rating(1500, 1, 0.0)
+        assert math.isfinite(result)
+        assert result < 1500
+
+
+# ---------------------------------------------------------------------------
+# get_calculation_rule — RP takes precedence over DK
+# ---------------------------------------------------------------------------
+
+class TestGetCalculationRulePrecedence:
+    def test_rp_takes_precedence_over_dk_in_fexerj_tournament(self, make_tournament_player):
+        """When both RP and DK conditions are met, RP must win in a FEXERJ tournament."""
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        # 5 games: RP threshold is 1.84, DK threshold is 1.43 — 2.0 satisfies both
+        p.this_games = 5
+        p.this_points_above_expected = 2.0
+        assert p.get_calculation_rule(is_fexerj_tournament=True) == "RATING_PERFORMANCE"
+
+    def test_dk_applies_when_rp_not_triggered_outside_fexerj(self, make_tournament_player):
+        """Outside a FEXERJ tournament, RP never applies; DK should trigger instead."""
+        p = make_tournament_player(is_temp=False, is_unrated=False)
+        p.this_games = 5
+        p.this_points_above_expected = 2.0
+        assert p.get_calculation_rule(is_fexerj_tournament=False) == "DOUBLE_K"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = old/tests
+pythonpath = old


### PR DESCRIPTION
Implement unit test suite with pytest for old/ module.

Added 102 unit tests covering FexerjPlayer, FexerjRatingCycle, TournamentPlayer, and Tournament classes. Tests validate core rating logic (NORMAL, DOUBLE_K, RATING_PERFORMANCE, TEMPORARY rules), opponent rating selection, player classification, CSV I/O, and processing order. Configured pytest with pytest.ini and added test-running instructions to README.

Closes #23.