### PR TITLE
Feature/33-create-git-actions-workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: python -m pytest old/tests/ -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+pytest


### PR DESCRIPTION
Sets up automated testing on GitHub Actions:
- Added `requirements.txt` with the project's dependencies (`requests`, `beautifulsoup4`, `pytest`)
- Added `.github/workflows/tests.yml` to run the full pytest suite on every push and pull request

### Node.js 20 deprecation warning

After pushing, GitHub Actions raised a warning that `actions/checkout@v4.2.2` and `actions/setup-python@v5.6.0` run on Node.js 20, which is being deprecated.

Two mitigations were attempted:                                                                                                                                                                           

1. Upgraded both actions to their latest versions — warning persisted
2. Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to the workflow — warning persisted

Since the tests run and pass successfully and the deadline for enforcing Node.js 24 is June 2nd, 2026, the decision was made to leave it as is. GitHub will make Node.js 24 the default after that date, which should resolve the warning automatically. 