### PR TITLE
Feature/18-check-all-del-self-and-remove-the-unecessary-ones

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -159,7 +159,6 @@ class TournamentPlayer:
         soup = BeautifulSoup(requests.get(url).content, 'lxml')
         tables = soup.find_all("table", class_="CRs1")
         if not len(tables):
-            del self
             return
         table = tables[0]
         rows = table.find_all("tr")


### PR DESCRIPTION
Remove no-op del self from TournamentPlayer.load_player_page as it does not destroy the object, it only removes the local name binding. The return alone is sufficient to deal with empty player rows.