### PR TITLE
Feature/9-add-log-informing-the-manual_entry_list-was-found

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -101,8 +101,11 @@ class FexerjRatingCycle:
 
     def load_manual_entry_dict(self):
         if os.path.exists('manual_entry_list.json'):
+            print("manual_entry_list.json found. Loading...")
             with open('manual_entry_list.json', 'r') as manual_entry_dict_file:
                 self.manual_entries = json.load(manual_entry_dict_file)
+        else:
+            print("manual_entry_list.json not found. A new one will be created if needed.")
 
     def write_manual_entry_dict(self):
         with open('manual_entry_list.json', 'w') as manual_entry_dict_file:

--- a/old/tests/test_fexerj_rating_cycle.py
+++ b/old/tests/test_fexerj_rating_cycle.py
@@ -98,14 +98,15 @@ class TestGetRatingList:
 
 
 class TestManualEntryDict:
-    def test_load_when_file_missing(self, tmp_path, monkeypatch):
+    def test_load_when_file_missing(self, tmp_path, monkeypatch, capsys):
         """load_manual_entry_dict should leave manual_entries empty when no file."""
         monkeypatch.chdir(tmp_path)
         cycle = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
         cycle.load_manual_entry_dict()
         assert cycle.manual_entries == {}
+        assert "not found" in capsys.readouterr().out
 
-    def test_write_and_reload(self, tmp_path, monkeypatch):
+    def test_write_and_reload(self, tmp_path, monkeypatch, capsys):
         """Writing then loading manual entries should round-trip correctly."""
         monkeypatch.chdir(tmp_path)
         cycle = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
@@ -115,3 +116,4 @@ class TestManualEntryDict:
         cycle2 = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
         cycle2.load_manual_entry_dict()
         assert cycle2.manual_entries == {"1.5": 999, "2.3": 888}
+        assert "found" in capsys.readouterr().out


### PR DESCRIPTION
Add logging to load_manual_entry_dict. Prints a message when manual_entry_list.json is found and loaded, or when it is not found and will be created if needed. Updates TestManualEntryDict tests to assert the correct messages are printed in each case.