### PR TITLE
Feature/7-add-tournament-to-invalid-turnament-type-message

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -68,7 +68,10 @@ class FexerjRatingCycle:
                     self.get_rating_list(self.initial_rating_filepath)
                     print("Reading from %s" % self.initial_rating_filepath)
                     print("Writing to %s" % self.final_rating_filepath)
-                    trn_type = TournamentType(tournament[4])
+                    try:
+                        trn_type = TournamentType(tournament[4])
+                    except ValueError:
+                        raise ValueError(f"Tournament {tournament[0]}: '{tournament[4]}' is not a valid TournamentType")
                     if trn_type == TournamentType.SS:
                         tournament = SwissSingleTournament(self, tournament)
                     elif trn_type == TournamentType.RR:

--- a/old/tests/test_fexerj_rating_cycle.py
+++ b/old/tests/test_fexerj_rating_cycle.py
@@ -107,6 +107,20 @@ class TestTournamentType:
         with pytest.raises(ValueError):
             TournamentType('XX')
 
+    def test_invalid_type_in_run_cycle_includes_tournament_number(self, tmp_path):
+        tournaments_csv = tmp_path / "tournaments.csv"
+        tournaments_csv.write_text(
+            "Id;CbxId;Name;Date;Type;IsIrt;IsFexerj\n"
+            "42;12345;Test Tournament;2025-01-01;XX;0;1\n"
+        )
+        ratings_csv = tmp_path / "ratings.csv"
+        ratings_csv.write_text(
+            "Id_No;Id_CBX;Title;Name;Rtg_Nat;ClubName;Birthday;Sex;Fed;TotalNumGames;SumOpponRating;TotalPoints\n"
+        )
+        cycle = FexerjRatingCycle(str(tournaments_csv), 42, 1, str(ratings_csv))
+        with pytest.raises(ValueError, match="42"):
+            cycle.run_cycle()
+
 
 class TestManualEntryDict:
     def test_load_when_file_missing(self, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Wraps the TournamentType() with a try/except to re-raise ValueError with the tournament number included. Adds unit test to assert the error message contains the tournament number.