### PR TITLE
Feature/46-replace-opponents-type-with-a-consistent-dict

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -148,7 +148,7 @@ class TournamentPlayer:
         self.snr = 0
         self.name = ""
         self.id = 0
-        self.opponents = []
+        self.opponents = {}
         self.tournament = tournament
         self.load_player_page(player_url)
         self.is_unrated = None
@@ -225,7 +225,7 @@ class TournamentPlayer:
                 res = '0.5'
             else:
                 res = result_char
-            self.opponents.append([sno, name, float(res)])
+            self.opponents[sno] = [name, float(res)]
 
     def keep_current_rating(self):
         # self.new_rating = self.this_rating = self.last_rating
@@ -395,9 +395,9 @@ class Tournament:
             else:
                 self.established_keys.append(snr)
 
-        # Convert each opponents array into dict and delete unrated opponents
+        # Replace opponent name/score entries with TournamentPlayer references
         for snr, tp in self.players.items():
-            tp.opponents = {opp[0]: [self.players[opp[0]], opp[2]] for opp in tp.opponents}
+            tp.opponents = {opp_snr: [self.players[opp_snr], data[1]] for opp_snr, data in tp.opponents.items()}
 
     def calculate_players_ratings(self):
         # First, calculates unrated

--- a/old/tests/test_tournament.py
+++ b/old/tests/test_tournament.py
@@ -26,7 +26,7 @@ def _make_tp(tournament, fexerj_id, snr, opponents_list=None):
     tp.id = fexerj_id
     tp.snr = snr
     tp.name = f"Player {fexerj_id}"
-    tp.opponents = opponents_list if opponents_list is not None else []
+    tp.opponents = opponents_list if opponents_list is not None else {}
     tp.is_unrated = None
     tp.is_temp = None
     return tp
@@ -120,8 +120,8 @@ class TestCompletePlersInfo:
         fp2 = _make_fexerj_player(2, total_games=50, last_rating=1600)
         t = _make_tournament(rating_list={1: fp1, 2: fp2})
 
-        tp1 = _make_tp(t, fexerj_id=1, snr=1, opponents_list=[[2, "Player 2", 1.0]])
-        tp2 = _make_tp(t, fexerj_id=2, snr=2, opponents_list=[[1, "Player 1", 0.0]])
+        tp1 = _make_tp(t, fexerj_id=1, snr=1, opponents_list={2: ["Player 2", 1.0]})
+        tp2 = _make_tp(t, fexerj_id=2, snr=2, opponents_list={1: ["Player 1", 0.0]})
         t.players = {1: tp1, 2: tp2}
 
         t.complete_players_info()

--- a/old/tests/test_tournament_player.py
+++ b/old/tests/test_tournament_player.py
@@ -15,33 +15,41 @@ from classes import TournamentPlayer, CalcRule, _MAX_NUM_GAMES_TEMP_RATING
 
 class TestAddOpponent:
     def test_win_added(self, make_tournament_player):
-        p = make_tournament_player(opponents=[])
+        p = make_tournament_player(opponents={})
         p.add_opponent(5, "Opponent A", "1")
         assert len(p.opponents) == 1
-        assert p.opponents[0] == [5, "Opponent A", 1.0]
+        assert p.opponents[5] == ["Opponent A", 1.0]
 
     def test_draw_added(self, make_tournament_player):
-        p = make_tournament_player(opponents=[])
+        p = make_tournament_player(opponents={})
         p.add_opponent(3, "Opponent B", "½")
-        assert p.opponents[0][2] == 0.5
+        assert p.opponents[3][1] == 0.5
 
     def test_loss_added(self, make_tournament_player):
-        p = make_tournament_player(opponents=[])
+        p = make_tournament_player(opponents={})
         p.add_opponent(7, "Opponent C", "0")
-        assert p.opponents[0][2] == 0.0
+        assert p.opponents[7][1] == 0.0
 
     def test_forfeit_ignored(self, make_tournament_player):
         """Results ending in 'K' (forfeit/absent) must not be stored."""
-        p = make_tournament_player(opponents=[])
+        p = make_tournament_player(opponents={})
         p.add_opponent(2, "Opponent D", "1K")
         assert len(p.opponents) == 0
 
     def test_multiple_opponents(self, make_tournament_player):
-        p = make_tournament_player(opponents=[])
+        p = make_tournament_player(opponents={})
         p.add_opponent(1, "A", "1")
         p.add_opponent(2, "B", "½")
         p.add_opponent(3, "C", "0")
         assert len(p.opponents) == 3
+
+    def test_duplicate_sno_overwrites(self, make_tournament_player):
+        """Adding two results for the same SNR keeps only the last entry."""
+        p = make_tournament_player(opponents={})
+        p.add_opponent(5, "Opponent A", "0")
+        p.add_opponent(5, "Opponent A", "1")
+        assert len(p.opponents) == 1
+        assert p.opponents[5][1] == 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The opponents collection was a list during page loading, then converted to a dict in a later step. It is now a dict from the start, removing the conversion step. Tests updated accordingly.