### PR TITLE
Feature/51-new-avg-oppon-rating-is-not-declared-in-__init__

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -167,6 +167,7 @@ class TournamentPlayer:
         self.this_points_above_expected = None
         self.new_rating = None
         self.new_total_games = None
+        self.new_avg_oppon_rating = None
         self.new_sum_oppon_ratings = None
         self.new_pts_against_oppon = None
         self.calc_rule = None

--- a/old/tests/conftest.py
+++ b/old/tests/conftest.py
@@ -51,6 +51,7 @@ def _make_tournament_player(tournament=None, **kwargs):
     player.this_points_above_expected = kwargs.get("this_points_above_expected", None)
     player.new_rating = kwargs.get("new_rating", None)
     player.new_total_games = kwargs.get("new_total_games", None)
+    player.new_avg_oppon_rating = kwargs.get("new_avg_oppon_rating", None)
     player.new_sum_oppon_ratings = kwargs.get("new_sum_oppon_ratings", None)
     player.new_pts_against_oppon = kwargs.get("new_pts_against_oppon", None)
     player.calc_rule = kwargs.get("calc_rule", None)


### PR DESCRIPTION
Declare `new_avg_oppon_rating` in `TournamentPlayer.__init__` and update `conftest` fixture. Closes #51