### PR TITLE
Feature/53-improve-add-opponent-method

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -224,13 +224,12 @@ class TournamentPlayer:
                 self.add_opponent(int(id_opponent), name_opponent, result_opponent)
 
     def add_opponent(self, sno, name, result):
-        result_char = result[-1]
-        if result_char != "K":
-            if result_char == "½":
-                res = '0.5'
-            else:
-                res = result_char
-            self.opponents[sno] = [name, float(res)]
+        result_map = {"1": 1.0, "0": 0.0, "½": 0.5, "K": None}
+        result_char = result[-1] if result else ""
+        if result_char not in result_map:
+            raise ValueError(f"Unexpected result '{result_char}' for opponent {name} (sno={sno})")
+        if result_map[result_char] is not None:
+            self.opponents[sno] = [name, result_map[result_char]]
 
     def keep_current_rating(self):
         # self.new_rating = self.this_rating = self.last_rating

--- a/old/tests/test_tournament_player.py
+++ b/old/tests/test_tournament_player.py
@@ -51,6 +51,16 @@ class TestAddOpponent:
         assert len(p.opponents) == 1
         assert p.opponents[5][1] == 1.0
 
+    def test_empty_result_raises(self, make_tournament_player):
+        p = make_tournament_player(opponents={})
+        with pytest.raises(ValueError, match="Unexpected result"):
+            p.add_opponent(1, "Opponent A", "")
+
+    def test_unrecognised_result_raises(self, make_tournament_player):
+        p = make_tournament_player(opponents={})
+        with pytest.raises(ValueError, match="Unexpected result"):
+            p.add_opponent(1, "Opponent A", "X")
+
 
 # ---------------------------------------------------------------------------
 # keep_current_rating


### PR DESCRIPTION
Improved add_opponent to raise ValueError on empty or unrecognised result characters; added unit tests. Closes #53.