### PR TITLE
Feature/6-implement-flags-argparse-on-command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ All players in the tournaments should already be in the first CSV.
 
 The user should run the following command:
 
-`python fexerj-rating-calculator.py <tournament_list_file> <first_torunament_to_run> <number_of_tournaments_to_run> <players_list_file>`
+`python fexerj-rating-calculator.py --tournaments <tournament_list_file> --players <players_list_file> --first <first_tournament_to_run> --count <number_of_tournaments_to_run>`
+
+`--count` is optional and defaults to `1`.
 
 The program will create one intermediate players' list file for each tournament in the following format:
 `RatingList_after_<number of the tournament>.csv`
@@ -65,11 +67,11 @@ The program will also create a JSON file with all the players for which the ID w
 
 To run the first 25 tournaments of the file:
 
-```python fexerj-rating-calculator.py tournaments.csv 1 25 players.csv```
+```python fexerj-rating-calculator.py --tournaments tournaments.csv --players players.csv --first 1 --count 25```
 
-To run only the 11th tournaments of the file (for example, if you find some issue with a given tournament in Chess Results page, fix it and want to rerun from that point of the cycle):
+To run only the 11th tournament of the file (for example, if you find some issue with a given tournament in Chess Results page, fix it and want to rerun from that point of the cycle):
 
-```python fexerj-rating-calculator.py tournaments.csv 11 1 players.csv```
+```python fexerj-rating-calculator.py --tournaments tournaments.csv --players players.csv --first 11 --count 1```
 
 
 ## IDE setup (PyCharm)

--- a/old/fexerj-rating-calculator.py
+++ b/old/fexerj-rating-calculator.py
@@ -1,9 +1,16 @@
 from classes import FexerjRatingCycle
-import sys
+import argparse
 
 # EXAMPLE
-# new_cycle = FexerjRatingCycle("torneios_2024R2.csv", 20, 2, "0_FexerjRating_202402.csv")
-new_cycle = FexerjRatingCycle(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), sys.argv[4])
+# python fexerj-rating-calculator.py --tournaments torneios_2024R2.csv --players 0_FexerjRating_202402.csv --first 20 --count 2
+parser = argparse.ArgumentParser(description="Calculate FEXERJ ratings from chess-results.com data.")
+parser.add_argument("--tournaments", required=True, help="Path to the tournament list CSV file")
+parser.add_argument("--players", required=True, help="Path to the players list CSV file")
+parser.add_argument("--first", type=int, required=True, help="First tournament to run (1-based index)")
+parser.add_argument("--count", type=int, default=1, help="Number of tournaments to run (default: 1)")
+args = parser.parse_args()
+
+new_cycle = FexerjRatingCycle(args.tournaments, args.first, args.count, args.players)
 new_cycle.load_manual_entry_dict()
 new_cycle.run_cycle()
 new_cycle.write_manual_entry_dict()


### PR DESCRIPTION
Replace positional sys.argv arguments with named argparse flags in main script, update README examples accordingly. Closes #6.