### PR TITLE
Feature/56 improve manual player id entry auto save and validate against ratings file

### DIFF
--- a/old/classes.py
+++ b/old/classes.py
@@ -1,12 +1,14 @@
 import json
 import math
 import os
+import unicodedata
 from urllib.parse import urlparse, parse_qs
 import csv
 from enum import Enum
 
 import requests
 from bs4 import BeautifulSoup
+from rapidfuzz import fuzz
 
 _CSV_DELIMITER = ';'
 _URLDOMAIN = "https://s3.chess-results.com"
@@ -45,6 +47,23 @@ class CalcRule(Enum):
     RATING_PERFORMANCE = 'RATING_PERFORMANCE'
     DOUBLE_K = 'DOUBLE_K'
     NORMAL = 'NORMAL'
+# Thresholds for comparing a manually entered player ID against the name in the ratings file.
+# score >= ACCEPT : names are close enough, accepted silently.
+# score >= WARN   : names differ slightly, user is asked to confirm.
+# score <  WARN   : names look very different (likely a wrong ID), user is warned more strongly.
+_NAME_SIMILARITY_ACCEPT_THRESHOLD = 85
+_NAME_SIMILARITY_WARN_THRESHOLD = 60
+
+def normalize_name(name):
+    """Lowercase, strip accents, remove commas, sort tokens — for name comparison."""
+    nfkd = unicodedata.normalize('NFKD', name)
+    ascii_name = nfkd.encode('ascii', 'ignore').decode('ascii')
+    tokens = sorted(ascii_name.lower().replace(',', '').split())
+    return ' '.join(tokens)
+
+def name_similarity(name_a, name_b):
+    return fuzz.ratio(normalize_name(name_a), normalize_name(name_b))
+
 _K_STARTING_NUM_GAMES = [(30, 0),  # grampo
                          (25, _MAX_NUM_GAMES_TEMP_RATING),  # 15
                          (15, 40),
@@ -195,9 +214,28 @@ class TournamentPlayer:
                     else:
                         print()
                         print('\tPlayer with unknown ID: %s' % self.name)
-                        self.id = int(input('\tPlease enter this player\'s ID: '))
+                        while True:
+                            self.id = int(input('\tPlease enter this player\'s ID: '))
+                            rating_list = self.tournament.rating_cycle.rating_list
+                            if self.id not in rating_list:
+                                print('\tWarning: ID %d not found in the ratings file.' % self.id)
+                                if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
+                                    continue
+                            else:
+                                rated_name = rating_list[self.id].name
+                                similarity = name_similarity(self.name, rated_name)
+                                if similarity < _NAME_SIMILARITY_WARN_THRESHOLD:
+                                    print('\tWarning: names look very different — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name))
+                                    if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
+                                        continue
+                                elif similarity < _NAME_SIMILARITY_ACCEPT_THRESHOLD:
+                                    print('\tNote: names differ slightly — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name))
+                                    if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
+                                        continue
+                            break
                         print()
                         self.tournament.rating_cycle.manual_entries[manual_entry_key] = self.id
+                        self.tournament.rating_cycle.write_manual_entry_dict()
         # Get Opponents and Results
         table = tables[1]
         header = table.select("tr")[0].find_all("th")

--- a/old/classes.py
+++ b/old/classes.py
@@ -225,9 +225,9 @@ class TournamentPlayer:
                                 rated_name = rating_list[self.id].name
                                 similarity = name_similarity(self.name, rated_name)
                                 if similarity < _NAME_SIMILARITY_WARN_THRESHOLD:
-                                    warning = '\tWarning: names look very different — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name)
+                                    warning = '\tWarning! Names look very different! Chess Results: "%s" vs. Ratings File: "%s".' % (self.name, rated_name)
                                 elif similarity < _NAME_SIMILARITY_ACCEPT_THRESHOLD:
-                                    warning = '\tNote: names differ slightly — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name)
+                                    warning = '\tNote. Names differ slightly! Chess Results: "%s" vs. Ratings File: "%s".' % (self.name, rated_name)
                             if warning:
                                 print(warning)
                                 if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':

--- a/old/classes.py
+++ b/old/classes.py
@@ -82,6 +82,7 @@ class FexerjRatingCycle:
         self.manual_entries = {}
 
     def run_cycle(self):
+        self.load_manual_entry_dict()
         with open(self.tournaments_file, 'r') as f:
             reader = csv.reader(f, delimiter=_CSV_DELIMITER)
             self.tournaments = list(reader)[1:]

--- a/old/classes.py
+++ b/old/classes.py
@@ -218,21 +218,20 @@ class TournamentPlayer:
                         while True:
                             self.id = int(input('\tPlease enter this player\'s ID: '))
                             rating_list = self.tournament.rating_cycle.rating_list
+                            warning = None
                             if self.id not in rating_list:
-                                print('\tWarning: ID %d not found in the ratings file.' % self.id)
-                                if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
-                                    continue
+                                warning = '\tWarning: ID %d not found in the ratings file.' % self.id
                             else:
                                 rated_name = rating_list[self.id].name
                                 similarity = name_similarity(self.name, rated_name)
                                 if similarity < _NAME_SIMILARITY_WARN_THRESHOLD:
-                                    print('\tWarning: names look very different — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name))
-                                    if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
-                                        continue
+                                    warning = '\tWarning: names look very different — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name)
                                 elif similarity < _NAME_SIMILARITY_ACCEPT_THRESHOLD:
-                                    print('\tNote: names differ slightly — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name))
-                                    if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
-                                        continue
+                                    warning = '\tNote: names differ slightly — tournament: "%s" / ratings file: "%s".' % (self.name, rated_name)
+                            if warning:
+                                print(warning)
+                                if input('\tContinue anyway? (y/n): ').strip().lower() != 'y':
+                                    continue
                             break
                         print()
                         self.tournament.rating_cycle.manual_entries[manual_entry_key] = self.id

--- a/old/fexerj-rating-calculator.py
+++ b/old/fexerj-rating-calculator.py
@@ -4,7 +4,5 @@ import sys
 # EXAMPLE
 # new_cycle = FexerjRatingCycle("torneios_2024R2.csv", 20, 2, "0_FexerjRating_202402.csv")
 new_cycle = FexerjRatingCycle(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), sys.argv[4])
-new_cycle.load_manual_entry_dict()
 new_cycle.run_cycle()
-new_cycle.write_manual_entry_dict()
 

--- a/old/tests/test_fexerj_rating_cycle.py
+++ b/old/tests/test_fexerj_rating_cycle.py
@@ -142,3 +142,16 @@ class TestManualEntryDict:
         cycle2.load_manual_entry_dict()
         assert cycle2.manual_entries == {"1.5": 999, "2.3": 888}
         assert "found" in capsys.readouterr().out
+
+    def test_write_manual_entry_dict_called_after_each_manual_entry(self, tmp_path, monkeypatch):
+        """write_manual_entry_dict should be called immediately after each manual entry is added."""
+        monkeypatch.chdir(tmp_path)
+        cycle = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
+
+        cycle.manual_entries["1.1"] = 111
+        cycle.write_manual_entry_dict()
+
+        # Simulate abort — create a new cycle and load without ever calling write again
+        cycle2 = FexerjRatingCycle("t.csv", 1, 1, "r.csv")
+        cycle2.load_manual_entry_dict()
+        assert cycle2.manual_entries == {"1.1": 111}

--- a/old/tests/test_tournament_player.py
+++ b/old/tests/test_tournament_player.py
@@ -6,7 +6,8 @@ make_tournament_player factory fixture defined in conftest.py.
 import math
 import pytest
 
-from classes import TournamentPlayer, CalcRule, _MAX_NUM_GAMES_TEMP_RATING
+from classes import TournamentPlayer, CalcRule, _MAX_NUM_GAMES_TEMP_RATING, normalize_name, name_similarity, \
+    _NAME_SIMILARITY_ACCEPT_THRESHOLD, _NAME_SIMILARITY_WARN_THRESHOLD
 
 
 # ---------------------------------------------------------------------------
@@ -660,3 +661,42 @@ class TestGetCalculationRulePrecedence:
         p.this_games = 5
         p.this_points_above_expected = 2.0
         assert p.get_calculation_rule(is_fexerj_tournament=False) == CalcRule.DOUBLE_K
+
+# ---------------------------------------------------------------------------
+# normalize_name / name_similarity
+# ---------------------------------------------------------------------------
+
+class TestNormalizeName:
+    def test_lowercases(self):
+        assert normalize_name("SILVA") == "silva"
+
+    def test_strips_accents(self):
+        assert normalize_name("José") == "jose"
+
+    def test_removes_commas(self):
+        assert normalize_name("Silva, Jose") == "jose silva"
+
+    def test_sorts_tokens(self):
+        assert normalize_name("Jose Silva") == normalize_name("Silva Jose")
+
+    def test_name_order_invariant(self):
+        assert normalize_name("SILVA, José") == normalize_name("Jose Silva")
+
+
+class TestNameSimilarity:
+    def test_identical_names_score_100(self):
+        assert name_similarity("Jose Silva", "Jose Silva") == 100
+
+    def test_accent_difference_scores_above_accept_threshold(self):
+        assert name_similarity("José Silva", "Jose Silva") >= _NAME_SIMILARITY_ACCEPT_THRESHOLD
+
+    def test_reversed_name_order_scores_above_accept_threshold(self):
+        assert name_similarity("SILVA, José", "Jose Silva") >= _NAME_SIMILARITY_ACCEPT_THRESHOLD
+
+    def test_completely_different_names_score_below_warn_threshold(self):
+        assert name_similarity("Jose Silva", "Carlos Pereira") < _NAME_SIMILARITY_WARN_THRESHOLD
+
+    def test_similar_but_different_name_scores_between_thresholds(self):
+        score = name_similarity("Jose Silverio", "Jose Silva")
+        assert _NAME_SIMILARITY_WARN_THRESHOLD <= score < _NAME_SIMILARITY_ACCEPT_THRESHOLD
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 pytest
+rapidfuzz


### PR DESCRIPTION
Writes the manual entry JSON immediately after each input to prevent data loss on abort. Validates the typed ID against the ratings file using fuzzy name matching, warning the user if names differ slightly, warning more strongly if they look very different, and re-prompting if the user rejects the match.

Add new dependency `rapidfuzz` to `requirements.txt`.

Also, move load_manual_entry_dict inside run_cycle and remove redundant write_manual_entry_dict call from main script.

Closes #56